### PR TITLE
Null change in development branch

### DIFF
--- a/JenkinsFile
+++ b/JenkinsFile
@@ -1,4 +1,4 @@
-pipeline {
+pipeline { 
   agent any
   environment {
     WORKINGDIR = "./"


### PR DESCRIPTION
Introduced a space in JenkinsFile to check that the Jenkins does not build this branch
Work done during the DevOps Bootcamp (by GeeksHubs) with Juan Mesa 4/7/2020